### PR TITLE
Add workaround for Mac OS X

### DIFF
--- a/include/m3bp/configuration.hpp
+++ b/include/m3bp/configuration.hpp
@@ -17,6 +17,7 @@
 #define M3BP_CONFIGURATION_HPP
 
 #include <memory>
+#include <string>
 #include "m3bp/types.hpp"
 
 namespace m3bp {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,15 @@ cmake_minimum_required(VERSION 2.8)
 project(m3bp)
 
 set(M3BP_VERSION "0.1.1")
-option(ENABLE_LOCALITY "Enable locality support (hwloc is required)" On)
+
+if(APPLE)
+	set(DEFAULT_ENABLE_LOCALITY Off)
+else()
+	set(DEFAULT_ENABLE_LOCALITY On)
+endif()
+
+option(ENABLE_LOCALITY "Enable locality support (hwloc is required)"
+       ${DEFAULT_ENABLE_LOCALITY})
 
 set(M3BP_REVISION "$Format:%h$")
 if(NOT ${M3BP_REVISION} MATCHES "^[0-9a-f]+$")
@@ -26,6 +34,9 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 find_package(Threads REQUIRED)
 
 if(ENABLE_LOCALITY)
+	if(APPLE)
+		message(FATAL_ERROR "Locality support is not available on Mac OS X")
+	endif()
 	find_package(hwloc REQUIRED)
 	if(HWLOC_FOUND)
 		add_definitions(-DM3BP_LOCALITY_ENABLED)
@@ -35,7 +46,11 @@ endif()
 find_package(Boost 1.55 COMPONENTS log REQUIRED)
 add_definitions(-DBOOST_LOG_DYN_LINK)
 
-include_directories(${Boost_INCLUDE_DIR})
+if(APPLE)
+	add_definitions(-DM3BP_NO_THREAD_LOCAL)
+endif()
+
+include_directories(${Boost_INCLUDE_DIRS})
 include_directories(${HWLOC_INCLUDE_DIR})
 include_directories(.)
 include_directories(../include)
@@ -57,8 +72,11 @@ file(GLOB SOURCES
      "tasks/process/*.cpp")
 
 if(UNIX)
-	set(COMPILE_OPTIONS "-std=c++11 -g -Wall -Wextra -pthread")
-	set(LINK_OPTIONS    "-pthread")
+	set(COMPILE_OPTIONS "-std=c++11 -g -Wall -Wextra")
+	set(LINK_OPTIONS    " ")
+else()
+	set(COMPILE_OPTIONS " ")
+	set(LINK_OPTIONS    " ")
 endif()
 
 add_definitions(-DM3BP_VERSION="${M3BP_VERSION}")

--- a/src/api/input_port.cpp
+++ b/src/api/input_port.cpp
@@ -101,7 +101,7 @@ InputPort &InputPort::movement(Movement m){
 
 
 InputPort::ValueComparatorType InputPort::value_comparator() const {
-	return std::move(m_impl->value_comparator());
+	return m_impl->value_comparator();
 }
 
 InputPort &InputPort::value_comparator(ValueComparatorType comparator){

--- a/src/common/thread_specific.hpp
+++ b/src/common/thread_specific.hpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 Fixstars Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef M3BP_COMMON_THREAD_SPECIFIC_HPP
+#define M3BP_COMMON_THREAD_SPECIFIC_HPP
+
+#include <pthread.h>
+#include <stdexcept>
+
+namespace m3bp {
+
+template <typename T>
+class ThreadSpecific {
+
+private:
+	pthread_key_t m_tsd_key;
+
+	static void tsd_destructor(void *ptr){
+		if(ptr){ delete reinterpret_cast<T *>(ptr); }
+	}
+
+public:
+	ThreadSpecific(){
+		if(pthread_key_create(&m_tsd_key, &tsd_destructor) != 0){
+			throw std::runtime_error(
+				"An error occured on `pthread_key_create()`");
+		}
+	}
+	~ThreadSpecific(){
+		pthread_key_delete(m_tsd_key);
+	}
+
+	ThreadSpecific(const ThreadSpecific<T> &) = delete;
+	ThreadSpecific<T> &operator=(const ThreadSpecific<T> &) = delete;
+
+	T &get(){
+		auto ptr = pthread_getspecific(m_tsd_key);
+		if(ptr){ return *reinterpret_cast<T *>(ptr); }
+		T *created = new T();
+		if(pthread_setspecific(m_tsd_key, created)){
+			throw std::runtime_error(
+				"An error occured on `pthread_setspecific()`");
+		}
+		return *created;
+	}
+
+};
+
+}
+
+#endif
+

--- a/src/logging/profile_event_logger.cpp
+++ b/src/logging/profile_event_logger.cpp
@@ -409,8 +409,5 @@ size_type ProfileEventLogger::write_json(
 	return Logger::size;
 }
 
-
-thread_local ProfileEventLogger g_thread_local_event_logger;
-
 }
 

--- a/src/logging/profile_logger.cpp
+++ b/src/logging/profile_logger.cpp
@@ -19,6 +19,10 @@
 #include "m3bp/configuration.hpp"
 #include "graph/logical_graph.hpp"
 
+#ifdef M3BP_NO_THREAD_LOCAL
+#include "common/thread_specific.hpp"
+#endif
+
 namespace m3bp {
 
 void ProfileLogger::set_configuration(const Configuration &config){
@@ -94,10 +98,17 @@ ProfileLogger::ProfileLogger(
 }
 
 
+#ifdef M3BP_NO_THREAD_LOCAL
+static ThreadSpecific<ProfileEventLogger> g_ts_event_logger;
+ProfileEventLogger &ProfileLogger::thread_local_logger(){
+	return g_ts_event_logger.get();
+}
+#else
 ProfileEventLogger &ProfileLogger::thread_local_logger(){
 	static thread_local ProfileEventLogger s_thread_local_event_logger;
 	return s_thread_local_event_logger;
 }
+#endif
 
 void ProfileLogger::flush_thread_local_log(identifier_type worker_id){
 	auto log_json = thread_local_logger().to_json();

--- a/src/tasks/logical_task_base.hpp
+++ b/src/tasks/logical_task_base.hpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <vector>
+#include <string>
 #include "tasks/logical_task_identifier.hpp"
 #include "tasks/physical_task_identifier.hpp"
 #include "memory/memory_reference.hpp"

--- a/src/tasks/shuffle/shuffle_logical_task.cpp
+++ b/src/tasks/shuffle/shuffle_logical_task.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <array>
 #include <cassert>
 #include <cstring>
 #include "tasks/shuffle/shuffle_logical_task.hpp"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,14 @@
 cmake_minimum_required(VERSION 2.8)
 project(m3bp-test)
 
-option(ENABLE_LOCALITY "Enable locality support (hwloc is required)" On)
+if(APPLE)
+	set(DEFAULT_ENABLE_LOCALITY Off)
+else()
+	set(DEFAULT_ENABLE_LOCALITY On)
+endif()
+
+option(ENABLE_LOCALITY "Enable locality support (hwloc is required)"
+       ${DEFAULT_ENABLE_LOCALITY})
 
 # do not install test-related components
 macro(install)
@@ -15,6 +22,9 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 find_package(Threads REQUIRED)
 
 if(ENABLE_LOCALITY)
+	if(APPLE)
+		message(FATAL_ERROR "Locality support is not available on Mac OS X")
+	endif()
 	find_package(hwloc REQUIRED)
 	if(HWLOC_FOUND)
 		add_definitions(-DM3BP_LOCALITY_ENABLED)
@@ -24,8 +34,13 @@ endif()
 find_package(Boost 1.55 COMPONENTS log REQUIRED)
 add_definitions(-DBOOST_LOG_DYN_LINK)
 
+if(APPLE)
+	add_definitions(-DM3BP_NO_THREAD_LOCAL)
+endif()
+
 include_directories(${gtest_SOURCE_DIR}/include)
 include_directories(${Boost_INCLUDE_DIRS})
+include_directories(${HWLOC_INCLUDE_DIR})
 include_directories(.)
 include_directories(../include)
 include_directories(../src)
@@ -33,6 +48,7 @@ include_directories(../src)
 file(GLOB TEST_SOURCES
      "main.cpp"
      "api/*.cpp"
+     "common/*.cpp"
      "context/*.cpp"
      "util/*.cpp"
      "scheduler/*.cpp"
@@ -43,7 +59,10 @@ file(GLOB TEST_SOURCES
 
 if(UNIX)
 	set(COMPILE_OPTIONS "-std=c++11 -g -Wall -Wextra")
-	set(LINK_OPTIONS    "-pthread")
+	set(LINK_OPTIONS    " ")
+else()
+	set(COMPILE_OPTIONS " ")
+	set(LINK_OPTIONS    " ")
 endif()
 
 add_executable(m3bp-test ${TEST_SOURCES})

--- a/test/common/thread_specific_test.cpp
+++ b/test/common/thread_specific_test.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Fixstars Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include <thread>
+#include <atomic>
+#include "common/thread_specific.hpp"
+
+namespace {
+
+std::atomic<int> g_dtor_counter;
+
+struct TestCounter {
+	int value;
+	TestCounter() : value(1) { }
+	~TestCounter(){ g_dtor_counter += value; }
+};
+
+m3bp::ThreadSpecific<TestCounter> g_ts_test_counter;
+
+}
+
+TEST(ThreadSpecific, GetAndSet){
+	const int num_threads = 4;
+	std::vector<std::thread> threads(num_threads);
+	g_dtor_counter.store(0);
+	for(int i = 0; i < num_threads; ++i){
+		threads[i] = std::thread([i](){
+			EXPECT_EQ(1, g_ts_test_counter.get().value);
+			g_ts_test_counter.get().value += i;
+		});
+	}
+	for(int i = 0; i < num_threads; ++i){
+		threads[i].join();
+		threads[i] = std::thread();
+	}
+	const int expected = (num_threads + 1) * num_threads / 2;
+	EXPECT_EQ(expected, g_dtor_counter.load());
+}
+

--- a/test/system/topology_test.cpp
+++ b/test/system/topology_test.cpp
@@ -60,7 +60,7 @@ TEST(Topology, SystemInfo){
 	auto &topo = m3bp::Topology::instance();
 	const auto num_pu = topo.total_processing_unit_count();
 	EXPECT_EQ(available_processor_count(), num_pu);
-	EXPECT_GE(num_pu, 1);
+	EXPECT_GE(num_pu, 1u);
 	const auto num_nodes = topo.numa_node_count();
 	m3bp::size_type sum = 0;
 	for(m3bp::identifier_type i = 0; i < num_nodes; ++i){


### PR DESCRIPTION
- Use pthread thread specific data for thread local storage
  - `thread_local` specifier is not supported on Mac OS X
- Fix compilation errors on Apple LLVM 7.3.0
- Disable locality supports on Mac OS X
  - `hwloc_set_cpubind` is not supported on Darwin
  - https://github.com/open-mpi/hwloc/blob/master/hwloc/bind.c
